### PR TITLE
feat(consultingapis):add grade chat group APIs(create,get,merge,sync)

### DIFF
--- a/consultingapis/dingtalk/v1/dingtalk.proto
+++ b/consultingapis/dingtalk/v1/dingtalk.proto
@@ -31,6 +31,31 @@ service DingTalkService {
       get: "/dingtalk/chat/v1/sync"
     };
   }
+
+  rpc CreateGradeChatGroup(CreateClassChatGroupRequest) returns (CreateClassChatGroupResponse) {
+    option (google.api.http) = {
+      post: "/dingtalk/chat/v1/createp-grade"
+      body: "body"
+    };
+  }
+
+  rpc GetGradeChatGroup(GetClassChatGroupRequest) returns (GetClassChatGroupResponse) {
+    option (google.api.http) = {
+      get: "/dingtalk/chat/v1/get-grade"
+    };
+  }
+
+  rpc MergeGradeChatGroup(MergeClassChatGroupRequest) returns (MergeClassChatGroupResponse) {
+    option (google.api.http) = {
+      get: "/dingtalk/chat/v1/merge-grade"
+    };
+  }
+
+  rpc SyncGradeChatGroup(SyncClassChatGroupRequest) returns (SyncClassChatGroupResponse) {
+    option (google.api.http) = {
+      get: "/dingtalk/chat/v1/sync-grade"
+    };
+  }
 }
 
 message CreateClassChatGroupRequest {
@@ -77,3 +102,54 @@ message SyncClassChatGroupRequest {
 message SyncClassChatGroupResponse {
   string message = 1;
 }
+
+
+message CreateGradeChatGroupRequest {
+  string unitId = 1; // 学院ID
+  string grade = 2; // 年级
+  Body body = 3;
+
+  message Body {
+    string name = 1;
+  }
+}
+
+message CreateGradeChatGroupResponse {
+  string chat_id = 1;
+  string openConversationId = 2;
+  string invite_url = 3;
+}
+
+message MergeGradeChatGroupRequest {
+  string unitId = 1;
+  string grade = 2;
+  string openConversationId = 3;
+}
+
+message MergeGradeChatGroupResponse {}
+
+message GetGradeChatGroupRequest {
+  string unitId = 1;
+  string grade = 2;
+}
+
+message GetGradeChatGroupResponse {
+  repeated Chat chats = 1;
+
+  message Chat {
+    string chat_id = 1;
+    string openConversationId = 2;
+    string invite_url = 3;
+    int64 created_at = 4;
+  }
+}
+
+message SyncGradeChatGroupRequest {
+  string unitId = 1;
+  string grade = 2;
+}
+
+message SyncGradeChatGroupResponse {
+  string message = 1;
+}
+

--- a/consultingapis/dingtalk/v1/dingtalk.proto
+++ b/consultingapis/dingtalk/v1/dingtalk.proto
@@ -32,26 +32,26 @@ service DingTalkService {
     };
   }
 
-  rpc CreateGradeChatGroup(CreateClassChatGroupRequest) returns (CreateClassChatGroupResponse) {
+  rpc CreateGradeChatGroup(CreateGradeChatGroupRequest) returns (CreateGradeChatGroupResponse) {
     option (google.api.http) = {
-      post: "/dingtalk/chat/v1/createp-grade"
+      post: "/dingtalk/chat/v1/create-grade"
       body: "body"
     };
   }
 
-  rpc GetGradeChatGroup(GetClassChatGroupRequest) returns (GetClassChatGroupResponse) {
+  rpc GetGradeChatGroup(GetGradeChatGroupRequest) returns (GetGradeChatGroupResponse) {
     option (google.api.http) = {
       get: "/dingtalk/chat/v1/get-grade"
     };
   }
 
-  rpc MergeGradeChatGroup(MergeClassChatGroupRequest) returns (MergeClassChatGroupResponse) {
+  rpc MergeGradeChatGroup(MergeGradeChatGroupRequest) returns (MergeGradeChatGroupResponse) {
     option (google.api.http) = {
       get: "/dingtalk/chat/v1/merge-grade"
     };
   }
 
-  rpc SyncGradeChatGroup(SyncClassChatGroupRequest) returns (SyncClassChatGroupResponse) {
+  rpc SyncGradeChatGroup(SyncGradeChatGroupRequest) returns (SyncGradeChatGroupResponse) {
     option (google.api.http) = {
       get: "/dingtalk/chat/v1/sync-grade"
     };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced methods for managing grade-specific chat groups:
		- **CreateGradeChatGroup**: Create a new chat group for a specific grade.
		- **GetGradeChatGroup**: Retrieve existing grade chat group information.
		- **MergeGradeChatGroup**: Merge multiple grade chat groups into one.
		- **SyncGradeChatGroup**: Synchronize grade chat groups for updates. 

These enhancements improve the management and organization of chat groups within the DingTalk service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->