### PR TITLE
fix(grpc-gateway): support application/json and wildcard marshaler in ServeMux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 .idea
+test_marshaler.go

--- a/api/grpc_gateway/mux.go
+++ b/api/grpc_gateway/mux.go
@@ -22,7 +22,28 @@ var DefaultServeMuxOption = []runtime.ServeMuxOption{
 	runtime.WithErrorHandler(DefaultErrorHandler),
 	runtime.WithRoutingErrorHandler(DefaultRoutingErrorHandler),
 	runtime.WithIncomingHeaderMatcher(DefaultHeaderWarp),
+	// 标准 JSON 格式
+	runtime.WithMarshalerOption("application/json", &runtime.JSONPb{
+		MarshalOptions: protojson.MarshalOptions{
+			EmitUnpopulated: true,
+			UseProtoNames:   true,
+		},
+		UnmarshalOptions: protojson.UnmarshalOptions{
+			DiscardUnknown: false,
+		},
+	}),
+	// Protobuf JSON 格式
 	runtime.WithMarshalerOption("application/jsonpb", &runtime.JSONPb{
+		MarshalOptions: protojson.MarshalOptions{
+			EmitUnpopulated: true,
+			UseProtoNames:   true,
+		},
+		UnmarshalOptions: protojson.UnmarshalOptions{
+			DiscardUnknown: false,
+		},
+	}),
+	// 兜底方案：客户端没明确指定 Content-Type 时用这个
+	runtime.WithMarshalerOption(runtime.MIMEWildcard, &runtime.JSONPb{
 		MarshalOptions: protojson.MarshalOptions{
 			EmitUnpopulated: true,
 			UseProtoNames:   true,


### PR DESCRIPTION
背景
线上偶发报错：Failed to parse Content-Type: mime: no media type。
原因是网关只配置了 application/jsonpb，当客户端使用 application/json 或未明确传递内容协商头时，可能匹配失败。

本次修改
在网关 ServeMux 中新增 application/json 的 marshaler 配置
保留 application/jsonpb 的 marshaler 配置
新增 MIMEWildcard 兜底 marshaler，兼容未显式声明内容类型的请求
预期效果
支持 application/json 请求
支持 application/jsonpb 请求
在未显式传递 Accept/Content-Type 时仍可正常处理
避免再次出现 Content-Type 解析失败问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **改进**
  * 优化了 API 响应序列化处理机制，增强了 JSON 格式的标准化处理。
  * 改进了对未指定 Content-Type 请求的默认处理支持。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->